### PR TITLE
Fix bad char used for temperature sensor

### DIFF
--- a/custom_components/sermatec_inverter/sensor.py
+++ b/custom_components/sermatec_inverter/sensor.py
@@ -94,7 +94,7 @@ async def async_setup_entry(
             dict_key        = "battery_temperature",
             name            = "Battery temperature",
             device_class    = "temperature",
-            unit            = "˚C"
+            unit            = "°C"
         ),
         SermatecSensor(
             coordinator     = coordinator,


### PR DESCRIPTION
The char used in unit string was not the expected one, similar, but not equal... it has been fixed.

Fix https://github.com/andreondra/homeassistant-sermatec-inverter/issues/18